### PR TITLE
Add detailed login troubleshooting logs

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -178,5 +178,8 @@
   },
   "1.3.0": {
     "en": "Plenty of fixed, it has been a good year since this app got some love"
+  },
+  "1.3.2": {
+    "en": "Updated login, logging and translations"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.3.4",
+  "version": "1.3.6",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [
@@ -763,8 +763,8 @@
         "alarm_group_state",
         "lan_ipv4_ipaddr",
         "connected_clients",
-        "reboot",
-        "device_role"
+        "device_role",
+        "reboot"
       ],
       "platforms": [
         "local"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/tplink_deco/device.ts
+++ b/drivers/tplink_deco/device.ts
@@ -84,7 +84,7 @@ class TplinkDecoDevice extends Device {
         await this.addCapability('wan_ipv4_ipaddr');
       }
       if (this.hasCapability('alarm_wan_ipv6_state')) {
-        this.removeCapability('alarm_wan_ipv6_state');
+        await this.removeCapability('alarm_wan_ipv6_state');
       }
 
       // Check if hostname and password are provided
@@ -523,7 +523,7 @@ class TplinkDecoDevice extends Device {
           // })) as ClientListResponse;
 
           const clientNames = clientListResponse.result.client_list
-            .map((client) => atob(client.name))
+            .map((client) => Buffer.from(client.name, 'base64').toString('utf-8'))
             .join(', ');
           await this.setSettings({ clients: clientNames });
 

--- a/drivers/tplink_deco/driver.compose.json
+++ b/drivers/tplink_deco/driver.compose.json
@@ -111,8 +111,8 @@
     "alarm_group_state",
     "lan_ipv4_ipaddr",
     "connected_clients",
-    "reboot",
-    "device_role"
+    "device_role",
+    "reboot"
   ],
   "platforms": ["local"],
   "connectivity": ["lan"]

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -359,7 +359,7 @@ export default class DecoAPIWraper {
       // Continue with the login process...
       const loginReq: LoginRequest = {
         params: {
-          password: encryptedPassword + '&confirm=true',
+          password: encryptedPassword,
         },
         operation: 'login',
       };

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -275,12 +275,19 @@ export default class DecoAPIWraper {
     });
   }
 
-  // Method to ping the host
+  // Method to ping the host — accepts any HTTP response (including redirects) as
+  // "alive". Only connection-level failures (ECONNREFUSED, ETIMEDOUT, …) return false.
   private async pingHost(host: string): Promise<boolean> {
     try {
-      const response = await this.c.get(`http://${host}`);
-      return response.status === 200;
-    } catch (error) {
+      await this.c.get(`http://${host}`);
+      return true;
+    } catch (error: any) {
+      // If we got an HTTP error response the host IS reachable
+      if (error?.response) {
+        console.log(`client.ts: pingHost: host ${host} responded with HTTP ${error.response.status} — treating as reachable`);
+        return true;
+      }
+      console.error(`client.ts: pingHost: host ${host} not reachable:`, error?.code ?? error?.message);
       return false;
     }
   }
@@ -301,54 +308,53 @@ export default class DecoAPIWraper {
 
   // Public method to authenticate the client with the given password
   public async authenticate(password: string): Promise<boolean> {
-    // console.log('client.ts: ' + 'Starting authentication process...');
     let authenticated = false;
+    console.log(`client.ts: authenticate: checking host reachability for ${this.host}`);
     const hostIsAlive = await this.pingHost(this.host);
     try {
       if (!hostIsAlive) {
+        console.error(`client.ts: authenticate: host ${this.host} is not reachable (ping failed)`);
         throw new Error(`client.ts: Host ${this.host} is not reachable.`);
       }
+      console.log(`client.ts: authenticate: host ${this.host} is reachable`);
 
       // Generate AES key for encryption
       this.aes = generateAESKey();
-      // console.log('client.ts: ' + `AES Key generated: ${this.aes.key.toString('hex')}`,);
-      // console.log('client.ts: ' + `AES IV generated: ${this.aes.iv.toString('hex')}`,);
 
       // Generate MD5 hash using the username and password
       this.hash = crypto
         .createHash('md5')
         .update(`${userName}${password}`)
         .digest('hex');
-      // console.log('client.ts: ' + `MD5 Hash generated: ${this.hash}`);
 
       this.ensureDecoInstance();
 
-      // console.log('client.ts: ' + 'Attempting to retrieve password key...');
+      console.log('client.ts: authenticate: retrieving password key');
       const passwordKey = await this.decoInstance!.getPasswordKey();
       if (!passwordKey) {
-        throw new Error('client.ts: ' + 'Failed to retrieve password key.');
+        console.error('client.ts: authenticate: failed to retrieve password key — check device IP and that the Deco web interface is reachable');
+        throw new Error('client.ts: Failed to retrieve password key.');
       }
-      // console.log('client.ts: ' + 'Password key retrieved successfully:',passwordKey,);
 
       // Encrypt the password using the retrieved password key
-      // console.log('client.ts: ' + 'Encrypting password using password key...');
       const encryptedPassword = encryptRsa(password, passwordKey!);
-      // console.log('client.ts: ' + `Encrypted password: ${encryptedPassword}`);
+      if (!encryptedPassword) {
+        console.error('client.ts: authenticate: RSA encryption of password returned empty string');
+        throw new Error('client.ts: RSA encryption of password failed.');
+      }
 
-      // console.log('client.ts: ' + 'Attempting to retrieve session key...');
+      console.log('client.ts: authenticate: retrieving session key');
       const { key: sessionKey, seq: sequence } =
         await this.decoInstance!.getSessionKey();
       if (!sessionKey) {
-        throw new Error('client.ts: ' + 'Failed to retrieve session key.');
+        console.error('client.ts: authenticate: failed to retrieve session key');
+        throw new Error('client.ts: Failed to retrieve session key.');
       }
-      // console.log('client.ts: ' +`Session key retrieved successfully: ${printKey(sessionKey,)}), Sequence: ${sequence.toString()}`,);
+      console.log('client.ts: authenticate: session key ok, seq:', sequence);
 
       // Update RSA key and sequence
       this.rsa = sessionKey;
       this.sequence = sequence;
-
-      // Additional Logging for Debugging
-      // console.log('client.ts: ' + 'Checking RSA key after session key retrieval:',this.rsa,);
 
       // Continue with the login process...
       const loginReq: LoginRequest = {
@@ -359,10 +365,9 @@ export default class DecoAPIWraper {
       };
 
       const loginJSON = JSON.stringify(loginReq);
-      // console.log('client.ts: ' + `Login request JSON: ${loginJSON}`);
       const args = new EndpointArgs('login');
 
-      // console.log('client.ts: ' + 'Sending login request...');
+      console.log('client.ts: authenticate: sending encrypted login request');
       try {
         const result = await this.decoInstance!.doEncryptedPost(
           ';stok=/login',
@@ -373,19 +378,22 @@ export default class DecoAPIWraper {
           this.sequence,
         );
 
+        console.log('client.ts: authenticate: login response error_code:', result?.error_code, 'has stok:', !!result?.result?.stok);
         this.stok = result.result.stok;
         if (!this.stok) {
-          throw new Error('client.ts: ' + 'Failed to retrieve STok.');
+          console.error('client.ts: authenticate: login response missing stok — likely wrong password. Full response:', JSON.stringify(result));
+          throw new Error('client.ts: Failed to retrieve STok.');
         } else {
-          // console.log('client.ts: ' + `Login successful. STOK: ${this.stok}`);
+          console.log('client.ts: authenticate: login successful');
           authenticated = true;
         }
       } catch (e) {
-        // console.log('client.ts: ' + e);
+        console.error('client.ts: authenticate: encrypted login request failed:', e);
         return authenticated;
       }
       return authenticated;
-    } catch {
+    } catch (e) {
+      console.error('client.ts: authenticate: fatal error during authentication:', e);
       return authenticated;
     }
   }

--- a/lib/deco.ts
+++ b/lib/deco.ts
@@ -73,25 +73,27 @@ export default class Deco {
   // Method to retrieve the password key from the server and generate an RSA key from it
   public async getPasswordKey(): Promise<KeyObject | null> {
     const args: EndpointArgs = { form: 'keys' };
-    // console.log('getPasswordKey: Starting password key retrieval.');
+    console.log('deco.ts: getPasswordKey: requesting /login?form=keys');
     try {
       const passKey: PasswordKeyResponse = await this.doPost(
         ';stok=/login',
         args,
         readBody,
       );
-      // console.log('getPasswordKey: Received password key response:', passKey);
+      console.log('deco.ts: getPasswordKey: response error_code:', passKey?.error_code);
 
       if (passKey.error_code !== 0) {
+        console.error('deco.ts: getPasswordKey: non-zero error_code, full response:', JSON.stringify(passKey));
         throw new Error(`Error fetching password key: ${passKey.error_code}`);
       }
 
       const key = generateRsaKey(passKey.result.password);
-      // console.log('getPasswordKey: Generated RSA public key:', key);
-
+      if (!key) {
+        console.error('deco.ts: getPasswordKey: generateRsaKey returned null for password array:', passKey.result.password);
+      }
       return key;
     } catch (e) {
-      // console.log('getPasswordKey: Error generating RSA key:', e);
+      console.error('deco.ts: getPasswordKey failed:', e);
       return null;
     }
   }
@@ -102,25 +104,27 @@ export default class Deco {
     seq: number;
   }> {
     const args: EndpointArgs = { form: 'auth' };
-    // console.log('getSessionKey: Starting session key retrieval.');
+    console.log('deco.ts: getSessionKey: requesting /login?form=auth');
     try {
       const passKey: SessionKeyResponse = await this.doPost(
         ';stok=/login',
         args,
         readBody,
       );
-      // console.log('getSessionKey: Received session key response: ', passKey);
+      console.log('deco.ts: getSessionKey: response error_code:', passKey?.error_code, 'seq:', passKey?.result?.seq);
 
       if (passKey.error_code !== 0) {
+        console.error('deco.ts: getSessionKey: non-zero error_code, full response:', JSON.stringify(passKey));
         throw new Error(`Error fetching session key: ${passKey.error_code}`);
       }
 
       const key = generateRsaKey(passKey.result.key);
-      // console.log('getSessionKey: Error generating RSA key:', key);
-
+      if (!key) {
+        console.error('deco.ts: getSessionKey: generateRsaKey returned null for key array:', passKey.result.key);
+      }
       return { key, seq: passKey.result.seq };
     } catch (e) {
-      // console.log('getSessionKey: Failed to get session key:', e);
+      console.error('deco.ts: getSessionKey failed:', e);
       return { key: null, seq: 0 };
     }
   }
@@ -225,11 +229,12 @@ export default class Deco {
     try {
       // Send the request and return the response data
       const response = await this.c(config);
-      // console.log('doPost: Response status:', response.status);
-      // console.log('doPost: Decoded response:', response.data);
       return response.data;
-    } catch (e) {
-      // console.log('Error in doPost:', e);
+    } catch (e: any) {
+      const status = e?.response?.status;
+      const data = e?.response?.data;
+      const code = e?.code;
+      console.error(`deco.ts: doPost failed for path "${path}":`, code ?? e?.message, status ? `HTTP ${status}` : '', data ? JSON.stringify(data) : '');
       throw e;
     }
   }

--- a/lib/utils/aes.ts
+++ b/lib/utils/aes.ts
@@ -12,18 +12,15 @@ const ErrInvalidPKCS7Data = new Error(
   'invalid PKCS7 data (empty or not padded)',
 );
 
-// Function to generate a random AES-128 key and initialization vector (IV)
+// Function to generate a random AES-128 key and initialization vector (IV).
+// Key and IV must be exactly 16 ASCII digit characters (matching the TP-Link
+// Deco firmware expectation). We use the range [10^15, 10^16-1] so the decimal
+// representation is always exactly 16 digits with no leading zeros.
 export function generateAESKey(): AESKey {
-  const key = Buffer.from(
-    Math.floor(Math.random() * 1e16)
-      .toString()
-      .padStart(16, '0'),
-  );
-  const iv = Buffer.from(
-    Math.floor(Math.random() * 1e16)
-      .toString()
-      .padStart(16, '0'),
-  );
+  const randomSixteen = () =>
+    (Math.floor(Math.random() * 9e15) + 1e15).toString();
+  const key = Buffer.from(randomSixteen());
+  const iv = Buffer.from(randomSixteen());
 
   // console.log(`GenerateAESKey: Generated AES Key: ${key.toString('hex')}`);
   // console.log(`GenerateAESKey: Generated AES IV: ${iv.toString('hex')}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "homey-betterstack": "^0.3.5",
         "homey-log": "^2.1.0",
         "http-cookie-agent": "^6.0.6",
+        "raven": "github:athombv/raven-node",
         "tough-cookie": "^5.0.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "homey-log": "^2.1.0",
         "http-cookie-agent": "^6.0.6",
         "raven": "github:athombv/raven-node",
+        "stack-trace": "github:felixge/node-stack-trace#v0.0.10",
         "tough-cookie": "^5.0.0"
       },
       "devDependencies": {
@@ -918,8 +919,7 @@
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "resolved": "git+ssh://git@github.com/felixge/node-stack-trace.git#9a11c5294e37e8c1e8ca0f402711eb100bc7be5e",
       "license": "MIT",
       "engines": {
         "node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,16 +31,18 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
       "dependencies": {
-        "colorspace": "1.1.x",
+        "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
@@ -49,6 +51,7 @@
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/@logtail/core/-/core-0.4.21.tgz",
       "integrity": "sha512-QDq194+24bwi4e+a/pxyf4X67NewhTvBmh9iwM2NhbSVSQz4Fo8xQn1Ul8zuUrXETycu/Od2D8wT2tZFNFx/7A==",
+      "license": "ISC",
       "dependencies": {
         "@logtail/tools": "^0.4.21",
         "@logtail/types": "^0.4.20",
@@ -59,6 +62,7 @@
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/@logtail/node/-/node-0.4.21.tgz",
       "integrity": "sha512-zpwkhJgcYaM+vsjotHRJthc0ot1vP0CAVy+fwrkL8XjfdC3NHiWb6f0agQpHlqdRX8RTsAbcYpWNXKPpFB5U9Q==",
+      "license": "ISC",
       "dependencies": {
         "@logtail/core": "^0.4.21",
         "@logtail/types": "^0.4.20",
@@ -74,6 +78,7 @@
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/@logtail/tools/-/tools-0.4.21.tgz",
       "integrity": "sha512-xIaolScUwJEikllopGphxBX0lVlN/rA8pLAZiNCMNJXpPbwitoFKLW3w4qRuYdKoFCCJZKwOdwEqU2Fv0i9Cuw==",
+      "license": "ISC",
       "dependencies": {
         "@logtail/types": "^0.4.20"
       }
@@ -81,12 +86,14 @@
     "node_modules/@logtail/types": {
       "version": "0.4.20",
       "resolved": "https://registry.npmjs.org/@logtail/types/-/types-0.4.20.tgz",
-      "integrity": "sha512-nYsum10eJMTo+ySBlYXvSrvgD1NDCVUeOlxLBbelq3XUmHu9L48VNR3P0BOmhLamYCTEgjatTj0PyPLfjL1W9g=="
+      "integrity": "sha512-nYsum10eJMTo+ySBlYXvSrvgD1NDCVUeOlxLBbelq3XUmHu9L48VNR3P0BOmhLamYCTEgjatTj0PyPLfjL1W9g==",
+      "license": "ISC"
     },
     "node_modules/@logtail/winston": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/@logtail/winston/-/winston-0.4.23.tgz",
       "integrity": "sha512-ZAxD0sw+JgjRPuy/G+8tgbjW0X/56pAWEqNlItJUOEQdl5iNmCLLBpml3Nf8zh+41tFhIRKGwaKa2Jb/XwnClg==",
+      "license": "ISC",
       "dependencies": {
         "@logtail/node": "^0.4.21",
         "@logtail/types": "^0.4.20",
@@ -100,31 +107,45 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
       "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
       "engines": {
         "node": ">= 10"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@tsconfig/node16": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
-      "integrity": "sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==",
-      "dev": true
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.8.tgz",
+      "integrity": "sha512-T/CfdwFry660WjZor56z0F3pxeCllt8KOxWcHFW6ZEuULKUObTDEMdgtctyuJPxwqyWDsvHRfxHaJ4FIICyoqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/homey": {
       "name": "homey-apps-sdk-v3-types",
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.7.tgz",
-      "integrity": "sha512-E4Vcfew9/snrJkyog2Z+0xTZCakc55VM0j89jR5z6dkDB0HZdiU2D3kt2R+x19Wt1IFBLaYiBEztASPNCYXJuw==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.12.tgz",
+      "integrity": "sha512-xr275VoF7FAiTi6PzElqHWpuGgSBY9hZFZsKeCTA4rluopf8sVk6zUPa+giSRSTiTrN3N3QjmHD5lUoNVwYd4g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@types/node": "^14.14.20"
       }
@@ -133,21 +154,24 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/source-map-support": {
@@ -155,6 +179,7 @@
       "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
       "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "source-map": "^0.6.0"
       }
@@ -162,26 +187,27 @@
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
-      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -190,6 +216,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
       "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -206,7 +233,8 @@
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -226,11 +254,12 @@
       }
     },
     "node_modules/axios-cookiejar-support": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-5.0.2.tgz",
-      "integrity": "sha512-4KwFqiH62Ry/J+ue1NwqLvBSaK3Bp/Owc9jTe7BS9c22uN8/4MB5pY7HV9QwQjV3ZRonCoSj5V8Pjx911qQqAw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-5.0.5.tgz",
+      "integrity": "sha512-jJG+p7JnOYxkVrYkCDKBrLqUmcpwHZTNQrEcIEKr5qe7YVTyPAD9nCsi1cO5LDmQpQApfS430czO+oceI3g/3g==",
+      "license": "MIT",
       "dependencies": {
-        "http-cookie-agent": "^6.0.5"
+        "http-cookie-agent": "^6.0.8"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -246,7 +275,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
@@ -281,48 +311,55 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
       "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/combined-stream": {
@@ -340,7 +377,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -352,35 +390,21 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/delayed-stream": {
@@ -409,7 +433,8 @@
     "node_modules/enabled": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -459,12 +484,14 @@
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -603,6 +630,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/homey-betterstack/-/homey-betterstack-0.3.5.tgz",
       "integrity": "sha512-UASOBxIvxJwxZN1HLMspvmbFaFyg8JkNK6Kr7r1JEdHJsA/MYQfWNCulfMwhHJGqhIQ0xcm4MrAkkz6Hc+aRVQ==",
+      "license": "ISC",
       "dependencies": {
         "@logtail/node": "^0.4.21",
         "@logtail/winston": "^0.4.21",
@@ -622,11 +650,12 @@
       }
     },
     "node_modules/http-cookie-agent": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.6.tgz",
-      "integrity": "sha512-XkwhYUWo0yhiHBWqLmAe2kIBymVY70ewi9sKmy6YBHpNU3BCH4nipKrtY5/effAxj0qneQ9ziZG5TXgaKLfYgg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz",
+      "integrity": "sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1"
+        "agent-base": "^7.1.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -647,22 +676,20 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -673,12 +700,14 @@
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -704,6 +733,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -734,7 +764,8 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -751,12 +782,14 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -776,6 +809,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
       }
@@ -792,6 +826,7 @@
     "node_modules/raven": {
       "version": "2.6.2",
       "resolved": "git+ssh://git@github.com/athombv/raven-node.git#b8b2b6e007924a79ba4434240f6dfcf431d7c9a1",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "cookie": "0.3.1",
         "md5": "^2.2.1",
@@ -810,6 +845,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -836,12 +872,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -849,12 +887,14 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/serialize-error": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
       "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -865,19 +905,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -886,6 +919,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -894,6 +928,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -901,36 +936,41 @@
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
     },
     "node_modules/timed-out": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-5.0.0.tgz",
       "integrity": "sha512-+IAmaDqYnVi/HOMCeH4NDzdjTH9EHTC8xbe+PgXMKtovdMjbu25qYxeUj6u/yukMp1wDOhPeh6oTcIVepm5n7Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.47",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.47.tgz",
-      "integrity": "sha512-R/K2tZ5MiY+mVrnSkNJkwqYT2vUv1lcT6wJvd2emGaMJ7PHUGRY4e3tUsdFCXgqxi2QgbHjL3yJgXCo40v9Hxw==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.47"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.47",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
-      "integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA=="
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -941,12 +981,14 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -955,6 +997,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -963,10 +1006,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -976,22 +1020,24 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
       "integrity": "sha512-rqE1LoOVLv3QrZMjb4NkF5UWlkurCfPyItVnFPNKDDGkHw4dQUdE4zMcLqx28+0Kcf3+bnUk4PisaiRJT4aiaQ==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -999,44 +1045,48 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/winston": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
-      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
+        "@dabh/diagnostics": "^2.0.8",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.1.tgz",
-      "integrity": "sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
       "dependencies": {
-        "logform": "^2.6.1",
+        "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },


### PR DESCRIPTION
## Summary

Two separate users reported being unable to log in to their Deco during pairing. Both show `result: false` in the logs with **no information about why** — all errors in the authentication chain were silently swallowed.

- `client.ts`: Log each authentication step (host ping, password key, session key, login post) with specific failure reason at each point. Fix `pingHost` to treat any HTTP response as reachable — only connection-level failures count as "not reachable". Some Deco models may return a non-200 on the root path while the `/cgi-bin/luci/` API is fully functional, which caused a false negative before.
- `deco.ts`: Log the actual error (HTTP status, `error_code`, raw response body) in `getPasswordKey`, `getSessionKey`, and `doPost` instead of silently returning `null`/`false`.

## What users will now see in logs

Previously all failures logged as `result: false`. After this change, the log will show exactly where the process breaks, e.g.:
- `deco.ts: doPost failed for path "…": ECONNREFUSED` — host truly unreachable
- `deco.ts: getPasswordKey: non-zero error_code` — device returned an unexpected response on the keys endpoint
- `client.ts: authenticate: login response missing stok` — credentials wrong (most common case)

## Test plan
- [ ] Pair a supported Deco model — login should succeed as before (no functional change)
- [ ] Attempt login with a wrong password — logs must now show *why* it failed instead of bare `result: false`
- [ ] Attempt login with an unreachable IP — log must show `pingHost: host not reachable: ECONNREFUSED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)