### PR TITLE
Bump version to v1.4.38

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
Version bump to publish the pairing-navigation, session-limit retry, and Sentry-delivery fixes.