### PR TITLE
Fix RSA-key error spam, transient login timeouts, and stale master detection (v1.4.70)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -367,5 +367,8 @@
   },
   "1.4.69": {
     "en": "Reverted a loading screen added in 1.4.68 for the login step — it caused pairing to get stuck right after entering your hostname and password, with no way to continue. Login now works the same way it did before that change."
+  },
+  "1.4.70": {
+    "en": "Fixed a burst of \"RSA key is missing or undefined\" errors flooding diagnostic logs whenever a device's session couldn't be restored — polling now skips cleanly until the next re-authentication succeeds instead of hammering the router with requests guaranteed to fail. A single slow/dropped network reply while logging in (common on Deco nodes a couple of mesh hops away) no longer fails the whole login attempt — it's retried once before giving up. Also fixed the master Deco showing as a stale, unreachable node (with a wrong client count) after swapping which router is the mesh's main unit — flow cards and client presence now prefer whichever paired master is actually reachable."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "net.tornbloms.deco",
-  "version": "1.4.69",
+  "version": "1.4.70",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "net.tornbloms.deco",
-  "version": "1.4.69",
+  "version": "1.4.70",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/tplink_deco/device.ts
+++ b/drivers/tplink_deco/device.ts
@@ -83,6 +83,15 @@ class TplinkDecoDevice extends Device {
   // fires once per device per app run, not on every poll cycle.
   private authMethodReported = false;
 
+  // Consecutive failed polls (device unreachable, or absent from its own
+  // mesh's device_list). Used to mark the device unavailable after a
+  // sustained outage — see pollTick()/updateDeviceMetrics() — so a stale
+  // "master"/role setting from a node that's no longer reachable (e.g. after
+  // swapping which node is the mesh's main router) stops being trusted by
+  // getMasterDevice() in driver.ts.
+  private consecutiveFailures = 0;
+  private static readonly UNAVAILABLE_AFTER_FAILURES = 3;
+
   // Returns a logger that routes through the Homey SDK so output appears
   // in diagnostics reports as well as the real-time developer tools.
   private makeLogger(): AppLogger {
@@ -225,7 +234,7 @@ class TplinkDecoDevice extends Device {
           } else {
             const resumedInterval = (this.getSettings().timeoutSeconds || 30) * 1000;
             try {
-              await this.updateDeviceMetrics();
+              await this.pollTick();
             } catch (e: any) {
               this.error('Resume poll failed', e);
             }
@@ -275,10 +284,7 @@ class TplinkDecoDevice extends Device {
         this.startupDelayTimerId = setTimeout(async () => {
           this.startupDelayTimerId = null;
           try {
-            if (!this.connected) {
-              await this.reAuthenticate();
-            }
-            await this.updateDeviceMetrics();
+            await this.pollTick();
             this.setUpdateInterval(interval);
           } catch (e: any) {
             this.log('Startup delay timer: device already gone, skipping', e?.message);
@@ -382,10 +388,51 @@ class TplinkDecoDevice extends Device {
     // Set up a new interval with a small jitter (0–5 s) to prevent
     // devices that started at the same offset from drifting back in sync.
     this.timeoutSecondsIntervalId = setInterval(
-      this.updateDeviceMetrics.bind(this),
+      this.pollTick.bind(this),
       interval + Math.random() * 5000,
     );
     this.log(`Set update interval to ${interval / 1000} seconds`);
+  }
+
+  /**
+   * Single entry point for every periodic poll (startup timer, resume, and
+   * the recurring interval). Re-authenticates first when the session isn't
+   * known-good, and — unlike calling updateDeviceMetrics() directly — skips
+   * the poll entirely when that re-auth fails, instead of charging ahead
+   * into a run of API calls that are guaranteed to fail with "RSA key is
+   * missing or undefined" (this.api.rsa is only ever set by a successful
+   * login). That guaranteed-fail run used to produce a burst of duplicate
+   * error logs every poll cycle instead of one clear "still unreachable"
+   * line, without changing the eventual outcome (updateDeviceMetrics's own
+   * device_list check already re-triggers reAuthenticate on failure).
+   */
+  private async pollTick(): Promise<void> {
+    if (!this.connected) {
+      const ok = await this.reAuthenticate();
+      if (!ok) {
+        this.log('pollTick: not authenticated, skipping this poll cycle');
+        this.consecutiveFailures += 1;
+        await this.markUnavailableIfPersistent();
+        return;
+      }
+    }
+    await this.updateDeviceMetrics();
+  }
+
+  /**
+   * Marks the device unavailable after several consecutive failed polls, and
+   * clears that state as soon as a poll succeeds again (see updateDeviceMetrics).
+   * This exists so driver.ts's getMasterDevice() can tell a genuinely-stale
+   * device (e.g. a node that stopped being reachable after the mesh's main
+   * router was swapped) apart from one that's just mid-poll — its cached
+   * `role` setting is otherwise never refreshed, so a device that used to be
+   * master keeps reporting as master indefinitely once it can no longer be
+   * reached.
+   */
+  private async markUnavailableIfPersistent(): Promise<void> {
+    if (this.consecutiveFailures >= TplinkDecoDevice.UNAVAILABLE_AFTER_FAILURES && this.getAvailable()) {
+      await this.setUnavailable('Cannot reach this Deco node.').catch(this.error);
+    }
   }
 
   /**
@@ -477,6 +524,8 @@ class TplinkDecoDevice extends Device {
       // If the API returns an error or device_list is missing (empty stok returns { error_code:0, result:{} }),
       // the session has expired or was never established — re-auth and wait for next poll
       if (deviceList.error_code !== 0 || !deviceList.result?.device_list) {
+        this.consecutiveFailures += 1;
+        await this.markUnavailableIfPersistent();
         await this.reAuthenticate();
         return;
       }
@@ -490,6 +539,13 @@ class TplinkDecoDevice extends Device {
         this.debug(`${settings.hostname} onInit():Filtered device: `, device);
 
         if (device) {
+          // Successfully found ourselves in the mesh's own device_list — this
+          // node (and the `role` setting below) is fresh, not stale. Undo any
+          // unavailable state a prior outage left behind.
+          this.consecutiveFailures = 0;
+          if (!this.getAvailable()) {
+            await this.setAvailable().catch(this.error);
+          }
           // Report the settled auth method (Content-Type / body format / password
           // mode, all cached on this.api.c after the first successful login) paired
           // with this device's exact model/firmware. Building this up across users

--- a/drivers/tplink_deco/driver.ts
+++ b/drivers/tplink_deco/driver.ts
@@ -266,11 +266,22 @@ class TplinkDecoDriver extends Driver {
   /**
    * Finds the paired device representing the mesh's master node, which is the only
    * device that maintains meshTrackedClients. Returns undefined if no master is paired.
+   *
+   * A device's `role` setting is only refreshed on a successful poll (see
+   * updateDeviceMetrics in device.ts), so a node that stops being reachable —
+   * e.g. because the mesh's main router was swapped and this node is no longer
+   * (or never was, post-swap) the master — keeps reporting whatever role it
+   * last successfully saw indefinitely. Prefer a master device that's still
+   * marked available (i.e. has polled successfully recently); only fall back
+   * to a stale/unavailable one if that's genuinely all we have, so autocomplete
+   * and mesh-presence flow cards don't go dark just because none happen to be
+   * "fresh" yet (e.g. right after Homey restarts).
    */
   private getMasterDevice(): any | undefined {
-    return this.getDevices().find(
+    const masters = this.getDevices().filter(
       (d: any) => (d.getSettings?.().role ?? '').toLowerCase() === 'master',
     );
+    return masters.find((d: any) => d.getAvailable?.() !== false) ?? masters[0];
   }
 
   /**

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -336,6 +336,23 @@ export default class DecoAPIWraper {
     return false;
   }
 
+  // Retries a single password-key/session-key fetch once after a short delay
+  // on network failure (ETIMEDOUT, ECONNRESET, …) before giving up. A NETWORK:
+  // error here bails authenticate() out of its entire combo loop immediately
+  // (see authenticate()) rather than trying the next format — so one transient
+  // timeout on an otherwise-reachable mesh node (e.g. a satellite a couple of
+  // backhaul hops away under load) used to fail the whole login attempt
+  // outright instead of just this one request.
+  private async fetchKeyWithRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
+    try {
+      return await fn();
+    } catch (e: any) {
+      this.logger.log(`client.ts: fetchKeyWithRetry: ${label} fetch failed (${e?.code ?? e?.message}), retrying once`);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return fn();
+    }
+  }
+
   // Private method to ensure the Deco instance is initialized or updated
   private ensureDecoInstance() {
     if (!this.decoInstance) {
@@ -440,7 +457,7 @@ export default class DecoAPIWraper {
     this.logger.log('client.ts: attemptLogin: retrieving password key');
     let passwordKey;
     try {
-      passwordKey = await this.decoInstance!.getPasswordKey();
+      passwordKey = await this.fetchKeyWithRetry(() => this.decoInstance!.getPasswordKey(), 'password key');
     } catch (e: any) {
       this.logger.error('client.ts: attemptLogin: network error fetching password key:', e);
       throw Object.assign(new Error(`NETWORK: Cannot reach router at ${this.host}. Check the IP and that Homey is on the same network.`), { cause: e });
@@ -458,7 +475,7 @@ export default class DecoAPIWraper {
     this.logger.log('client.ts: attemptLogin: retrieving session key');
     let sessionKey, sequence;
     try {
-      ({ key: sessionKey, seq: sequence } = await this.decoInstance!.getSessionKey());
+      ({ key: sessionKey, seq: sequence } = await this.fetchKeyWithRetry(() => this.decoInstance!.getSessionKey(), 'session key'));
     } catch (e: any) {
       this.logger.error('client.ts: attemptLogin: network error fetching session key:', e);
       throw Object.assign(new Error(`NETWORK: Cannot reach router at ${this.host}. Check the IP and that Homey is on the same network.`), { cause: e });


### PR DESCRIPTION
## Summary

Addresses three root causes identified from the BE65/BE68 diagnostic report (Log ID `c7e11a8f-402b-47a3-8809-0e5d7529bcc4`) and issues #4 / #6:

1. **`RSA key is missing or undefined` log spam** — `onInit`'s startup timer and the periodic `setInterval` called `updateDeviceMetrics()` unconditionally, even right after a failed `reAuthenticate()`. Since `this.api.rsa` is only ever set by a successful login, every downstream API call in that poll cycle was guaranteed to throw, producing a burst of duplicate error logs per cycle. All poll entry points (startup timer, resume-after-pause, and the recurring interval) now go through a single `pollTick()` that skips the cycle cleanly with one log line when re-auth fails, instead of charging into calls known to fail.

2. **False "router unreachable" failures** — a single transient network error (`ETIMEDOUT`) fetching the password key or session key immediately threw a `NETWORK:` error, which bails `authenticate()` out of its *entire* login-format combo loop right away instead of trying the next combo. On a mesh satellite a couple of backhaul hops away, one slow reply during login doesn't mean the router is actually unreachable. Both fetches are now retried once after a short delay before giving up.

3. **Stale "master" device after swapping the main router** — a device's `role` setting is only refreshed on a successful poll, so a node that stops being reachable (e.g. it's no longer the mesh's main router) keeps reporting whatever role it last saw indefinitely — this matches the reported BE65 still showing as master with a wrong client count after a BE68 became the new main Deco. Devices are now marked unavailable after 3 consecutive failed polls (and available again on the next success), and `driver.ts`'s `getMasterDevice()` prefers an available master over a stale/unavailable one when building autocomplete and mesh-presence flow-card data.

## Not covered by this PR

The `Homey.getCurrentView is not a function` / `Homey.error is not a function` errors reported during web pairing come from Homey's own built-in `login_credentials`/`list_devices` pairing templates (this driver has no custom pairing HTML for those views — only `login_failed.html` is custom) — no occurrences of those calls exist in this repo. That symptom likely needs investigation on the Homey platform side rather than in this app.

## Test plan

- [x] `npx tsc --noEmit -p .` — compiles clean
- [x] `npm test` — existing `regression-login-combo-state` test passes
- [ ] Field-verify against a real BE65/BE68 mesh (diagnostic logs no longer show repeated RSA-missing bursts; master device stays correctly assigned after a main-router swap)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDwhXge77VqBtM7dGiNtsL)_